### PR TITLE
Fix Docker build: copy patches/ before pnpm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN corepack enable
 
 ## Utilize docker layer cache
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml /iframely/
+COPY patches/ /iframely/patches/
 RUN pnpm install --frozen-lockfile --prod
 
 COPY . /iframely


### PR DESCRIPTION
\`package.json\` declares a pnpm \`patchedDependencies\` entry for \`readabilitySAX@1.6.1\` that references \`patches/readabilitySAX@1.6.1.patch\`. The \`pnpm install\` step requires this file to exist at install time, but the previous \`COPY . /iframely\` instruction — which copies the patches directory — came *after* \`pnpm install\`. This caused the Docker build to fail.

**Fix:** Add an explicit \`COPY patches/ /iframely/patches/\` before \`pnpm install\`, alongside the existing \`COPY package.json pnpm-lock.yaml ...\` layer-cache step.